### PR TITLE
scan denormalized migrations

### DIFF
--- a/lib/trains/version.rb
+++ b/lib/trains/version.rb
@@ -1,3 +1,3 @@
 module Trains
-  VERSION = '0.0.8'
+  VERSION = '0.0.9'.freeze
 end

--- a/lib/trains/visitor/migration.rb
+++ b/lib/trains/visitor/migration.rb
@@ -121,36 +121,6 @@ module Trains
           elsif ddl_node.send_type?
             migrations = [*migrations, *parse_one_liner_migration(ddl_node)]
           end
-
-          # next unless ALLOWED_TABLE_MODIFIERS.include?(ddl_node.method_name)
-
-          # table_name = ddl_node.arguments[0].value.to_s.singularize.camelize
-          # if ALLOWED_TABLE_MODIFIERS.include?(send_node.method_name)
-          #   raw_table_name = send_node.arguments[0]
-          #   @table_name = raw_table_name.value.to_s.singularize.camelize
-          #   if COLUMN_MODIFIERS.include?(send_node.method_name)
-          #     @result.append(
-          #       DTO::Migration.new(
-          #         @table_name,
-          #         send_node.method_name,
-          #         [
-          #           DTO::Field.new(send_node.arguments[1].value,
-          #                          send_node.arguments[2]&.value)
-          #         ],
-          #         @migration_version
-          #       )
-          #     )
-          #   end
-          #
-          #   next
-          # end
-          #
-          # next if ALLOWED_TABLE_MODIFIERS.include?(send_node.method_name)
-          #
-
-          # ddl_node.each_descendant(:send) do |send_node|
-          #   fields = [*fields, *parse_migration_field(send_node)]
-          # end
         end
 
         migrations

--- a/lib/trains/visitor/migration.rb
+++ b/lib/trains/visitor/migration.rb
@@ -71,7 +71,7 @@ module Trains
         when :block
           @result = [*@result, *parse_block_migration(node)]
         else
-          pp node
+          LOGGER.debug(node)
         end
       end
 

--- a/lib/trains/visitor/migration.rb
+++ b/lib/trains/visitor/migration.rb
@@ -21,16 +21,9 @@ module Trains
       ].freeze
 
       def initialize
-        @model = nil
-        @table_modifier = nil
-        @table_name = nil
-        @is_class = false
-        @is_migration = false
-        @class_name = nil
-        @fields = []
         @result = []
-
-        @scope = { class: nil, method: nil, send: nil }
+        @migration_class = nil
+        @migration_version = nil
       end
 
       def on_class(node)

--- a/lib/trains/visitor/migration.rb
+++ b/lib/trains/visitor/migration.rb
@@ -5,7 +5,20 @@ module Trains
     # Visitor that parses DB migration and associates them with Rails models
     class Migration < Base
       def_node_matcher :send_node?, '(send nil? ...)'
-      attr_reader :is_migration, :model
+      attr_reader :is_migration, :model, :result
+
+      ALLOWED_METHOD_NAMES = %i[change up down].freeze
+      ALLOWED_TABLE_MODIFIERS = %i[
+        create_table
+        change_table
+        update_column
+        add_index
+      ].freeze
+      COLUMN_MODIFIERS = %i[
+        add_column
+        change_column
+        remove_column
+      ].freeze
 
       def initialize
         @model = nil
@@ -15,6 +28,7 @@ module Trains
         @is_migration = false
         @class_name = nil
         @fields = []
+        @result = []
 
         @scope = { class: nil, method: nil, send: nil }
       end
@@ -27,16 +41,7 @@ module Trains
         @migration_class = node.children.first.source
         @migration_version = extract_version(node.parent_class.source)
 
-        process_node(node.body)
-      end
-
-      def result
-        DTO::Migration.new(
-          table_name: @table_name,
-          modifier: @table_modifier,
-          fields: @fields,
-          version: @migration_version
-        )
+        process_def_node(node.body)
       end
 
       private
@@ -48,75 +53,124 @@ module Trains
         match.to_s.to_f
       end
 
-      def process_node(node)
+      def process_def_node(node)
         return unless node.def_type?
 
-        process_def_node(node)
-      end
-
-      def process_def_node(node)
-        allowed_method_names = %i[change up down]
-        allowed_table_modifiers = %i[
-          create_table
-          change_table
-          update_column
-          add_column
-          remove_column
-          change_column
-          add_index
-        ]
-        column_modifiers = %i[
-          add_column
-          change_column
-          remove_column
-        ]
-
         method_name = node.method_name
-        return unless allowed_method_names.include? method_name
+        unless ALLOWED_METHOD_NAMES.include?(method_name) || COLUMN_MODIFIERS.include?(method_name)
+          return
+        end
         return if node.body.nil?
 
-        table_modifier =
-          # if table modifier is a one-liner method call
-          if node.body.children[0].nil?
-            node.body.children[1]
-          elsif node.body.children[0].block_type?
-            # if table modifier is in a block
-            node.body.children[0].method_name
-          elsif node.body.children[0].send_type?
-            node.body.children[0].method_name
+        case node.body.type
+        when :send
+          @result << parse_one_liner_migration(node.body)
+        when :begin
+          if node.body.children.map(&:type).include?(:block)
+            migration = parse_block_migration(node)
+            @result = [*@result, *migration] if migration
+          else
+            node.body.each_descendant(:send) do |send_node|
+              migration = parse_one_liner_migration(send_node)
+              @result << migration if migration
+            end
           end
-        return unless allowed_table_modifiers.include? table_modifier
+        when :block
+          @result = [*@result, *parse_block_migration(node)]
+        else
+          pp node
+        end
+      end
 
-        @table_modifier = table_modifier
+      def parse_one_liner_migration(node)
+        return unless COLUMN_MODIFIERS.include?(node.method_name)
 
-        node.each_descendant(:send) do |send_node|
-          if allowed_table_modifiers.include?(send_node.method_name)
-            raw_table_name = send_node.arguments[0]
-            @table_name = raw_table_name.value.to_s.singularize.camelize
-            if column_modifiers.include?(send_node.method_name)
-              @fields.append(DTO::Field.new(send_node.arguments[1].value,
-                                            send_node.arguments[2]&.value))
+        arguments = node.arguments
+        table_name = arguments[0].value.to_s.singularize.camelize
+        column_name = arguments[1].value
+        type = arguments[2].value unless node.method_name == :remove_column
+
+        DTO::Migration.new(
+          table_name,
+          node.method_name,
+          [DTO::Field.new(column_name, type)],
+          @migration_version
+        )
+      end
+
+      def parse_block_migration(node)
+        migrations = []
+        # Visit every send_node that performs DDL tasks
+        node.each_descendant do |ddl_node|
+          fields = []
+
+          if ddl_node.block_type?
+            next unless ALLOWED_TABLE_MODIFIERS.include?(ddl_node.method_name)
+
+            table_name = ddl_node.send_node.arguments[0].value.to_s.singularize.camelize
+            ddl_node.body.each_descendant(:send) do |send_node|
+              fields = [*fields, *parse_migration_field(send_node)]
             end
 
-            next
+            migrations << DTO::Migration.new(
+              table_name,
+              ddl_node.method_name,
+              fields,
+              @migration_version
+            )
+          elsif ddl_node.send_type?
+            migrations = [*migrations, *parse_one_liner_migration(ddl_node)]
           end
 
-          next if allowed_table_modifiers.include?(send_node.method_name)
+          # next unless ALLOWED_TABLE_MODIFIERS.include?(ddl_node.method_name)
 
-          parse_migration_field(send_node)
+          # table_name = ddl_node.arguments[0].value.to_s.singularize.camelize
+          # if ALLOWED_TABLE_MODIFIERS.include?(send_node.method_name)
+          #   raw_table_name = send_node.arguments[0]
+          #   @table_name = raw_table_name.value.to_s.singularize.camelize
+          #   if COLUMN_MODIFIERS.include?(send_node.method_name)
+          #     @result.append(
+          #       DTO::Migration.new(
+          #         @table_name,
+          #         send_node.method_name,
+          #         [
+          #           DTO::Field.new(send_node.arguments[1].value,
+          #                          send_node.arguments[2]&.value)
+          #         ],
+          #         @migration_version
+          #       )
+          #     )
+          #   end
+          #
+          #   next
+          # end
+          #
+          # next if ALLOWED_TABLE_MODIFIERS.include?(send_node.method_name)
+          #
+
+          # ddl_node.each_descendant(:send) do |send_node|
+          #   fields = [*fields, *parse_migration_field(send_node)]
+          # end
         end
+
+        migrations
       end
 
       def parse_migration_field(node)
+        fields = []
         if node.children[1] == :timestamps
-          @fields.append(DTO::Field.new(:created_at, :datetime))
-          @fields.append(DTO::Field.new(:updated_at, :datetime))
-          return
+          fields << DTO::Field.new(:created_at, :datetime)
+          fields << DTO::Field.new(:updated_at, :datetime)
+          return fields
         end
+
+        return [] if node.arguments.nil? || node.arguments.empty?
 
         type = node.children[1]
         value = node.children[2].value unless node.children[2].hash_type?
-        @fields.append(DTO::Field.new(value, type))
+        fields << DTO::Field.new(value, type)
+
+        fields
       end
     end
   end

--- a/lib/trains/visitor/migration.rb
+++ b/lib/trains/visitor/migration.rb
@@ -20,6 +20,7 @@ module Trains
         remove_column
       ].freeze
 
+      # skipcq: RB-LI1087
       def initialize
         @result = []
         @migration_class = nil

--- a/spec/fixtures/denormalize_migration.rb
+++ b/spec/fixtures/denormalize_migration.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class DenormalizeExpressions < ActiveRecord::Migration[4.2]
+  def change
+    # Denormalizing this makes our queries so, so, so much nicer
+
+    add_column :posts, :expression1_count, :integer, null: false, default: 0
+    add_column :posts, :expression2_count, :integer, null: false, default: 0
+
+    add_column :forum_threads, :expression1_count, :integer, null: false, default: 0
+    add_column :forum_threads, :expression2_count, :integer, null: false, default: 0
+
+    (1..5).each do |i|
+      execute "update posts set expression#{i}_count = (select count(*) from expressions where parent_id = posts.id and expression_type_id = #{i})"
+      execute "update forum_threads set expression#{i}_count = (select sum(expression#{i}_count) from posts where forum_thread_id = forum_threads.id)"
+    end
+  end
+end

--- a/spec/lib/trains/visitor/migration_spec.rb
+++ b/spec/lib/trains/visitor/migration_spec.rb
@@ -19,6 +19,10 @@ describe Trains::Visitor::Migration do
     File.expand_path "#{__FILE__}/../../../../fixtures/create_people.rb"
   end
 
+  let(:denormalize_migration) do
+    File.expand_path "#{__FILE__}/../../../../fixtures/denormalize_migration.rb"
+  end
+
   context 'Given a valid DB migration file path' do
     it 'returns an object with its metadata' do
       parser = described_class.new
@@ -30,20 +34,22 @@ describe Trains::Visitor::Migration do
       file_ast.each_node { |node| parser.process(node) }
 
       expect(parser.result).to eq(
-        Trains::DTO::Migration.new(
-          table_name: 'Group',
-          modifier: :create_table,
-          fields: [
-            Trains::DTO::Field.new(:title, :string),
-            Trains::DTO::Field.new(:created_at, :datetime),
-            Trains::DTO::Field.new(:updated_at, :datetime)
-          ],
-          version: 7.0
-        )
+        [
+          Trains::DTO::Migration.new(
+            table_name: 'Group',
+            modifier: :create_table,
+            fields: [
+              Trains::DTO::Field.new(:title, :string),
+              Trains::DTO::Field.new(:created_at, :datetime),
+              Trains::DTO::Field.new(:updated_at, :datetime)
+            ],
+            version: 7.0
+          )
+        ]
       )
     end
 
-    it 'sdsd' do
+    it 'returns a valid migration' do
       parser = described_class.new
       file_ast =
         RuboCop::AST::ProcessedSource.from_file(
@@ -53,19 +59,21 @@ describe Trains::Visitor::Migration do
       file_ast.each_node { |node| parser.process(node) }
 
       expect(parser.result).to eq(
-        Trains::DTO::Migration.new(
-          table_name: 'Person',
-          modifier: :create_table,
-          fields: [
-            Trains::DTO::Field.new(:name, :string),
-            Trains::DTO::Field.new(:age, :integer),
-            Trains::DTO::Field.new(:job, :string),
-            Trains::DTO::Field.new(:bio, :text),
-            Trains::DTO::Field.new(:created_at, :datetime),
-            Trains::DTO::Field.new(:updated_at, :datetime)
-          ],
-          version: 7.0
-        )
+        [
+          Trains::DTO::Migration.new(
+            table_name: 'Person',
+            modifier: :create_table,
+            fields: [
+              Trains::DTO::Field.new(:name, :string),
+              Trains::DTO::Field.new(:age, :integer),
+              Trains::DTO::Field.new(:job, :string),
+              Trains::DTO::Field.new(:bio, :text),
+              Trains::DTO::Field.new(:created_at, :datetime),
+              Trains::DTO::Field.new(:updated_at, :datetime)
+            ],
+            version: 7.0
+          )
+        ]
       )
     end
   end
@@ -81,17 +89,19 @@ describe Trains::Visitor::Migration do
       file_ast.each_node { |node| parser.process(node) }
 
       expect(parser.result).to eq(
-        Trains::DTO::Migration.new(
-          table_name: 'GroupUser',
-          modifier: :create_table,
-          fields: [
-            Trains::DTO::Field.new(:group_id, :integer),
-            Trains::DTO::Field.new(:user_id, :integer),
-            Trains::DTO::Field.new(:created_at, :datetime),
-            Trains::DTO::Field.new(:updated_at, :datetime)
-          ],
-          version: 4.2
-        )
+        [
+          Trains::DTO::Migration.new(
+            table_name: 'GroupUser',
+            modifier: :create_table,
+            fields: [
+              Trains::DTO::Field.new(:group_id, :integer),
+              Trains::DTO::Field.new(:user_id, :integer),
+              Trains::DTO::Field.new(:created_at, :datetime),
+              Trains::DTO::Field.new(:updated_at, :datetime)
+            ],
+            version: 4.2
+          )
+        ]
       )
     end
   end
@@ -107,12 +117,14 @@ describe Trains::Visitor::Migration do
       file_ast.each_node { |node| parser.process(node) }
 
       expect(parser.result).to eq(
-        Trains::DTO::Migration.new(
-          table_name: 'Post',
-          modifier: :remove_column,
-          fields: [Trains::DTO::Field.new(:reply_below_post_number, nil)],
-          version: 4.2
-        )
+        [
+          Trains::DTO::Migration.new(
+            table_name: 'Post',
+            modifier: :remove_column,
+            fields: [Trains::DTO::Field.new(:reply_below_post_number, nil)],
+            version: 4.2
+          )
+        ]
       )
     end
   end
@@ -128,13 +140,56 @@ describe Trains::Visitor::Migration do
       file_ast.each_node { |node| parser.process(node) }
 
       expect(parser.result).to eq(
-        Trains::DTO::Migration.new(
-          table_name: 'UserStat',
-          modifier: :add_column,
-          fields: [Trains::DTO::Field.new(:pending_posts_count, :integer)],
-          version: 6.1
-        )
+        [
+          Trains::DTO::Migration.new(
+            table_name: 'UserStat',
+            modifier: :add_column,
+            fields: [Trains::DTO::Field.new(:pending_posts_count, :integer)],
+            version: 6.1
+          )
+        ]
       )
+    end
+
+    context 'Given a denormalized DB migration' do
+      it 'returns an object with its metadata' do
+        parser = described_class.new
+        file_ast =
+          RuboCop::AST::ProcessedSource.from_file(
+            denormalize_migration,
+            RUBY_VERSION.to_f
+          ).ast
+        file_ast.each_node { |node| parser.process(node) }
+
+        expect(parser.result).to eq(
+          [
+            Trains::DTO::Migration.new(
+              table_name: 'Post',
+              modifier: :add_column,
+              fields: [Trains::DTO::Field.new(:expression1_count, :integer)],
+              version: 4.2
+            ),
+            Trains::DTO::Migration.new(
+              table_name: 'Post',
+              modifier: :add_column,
+              fields: [Trains::DTO::Field.new(:expression2_count, :integer)],
+              version: 4.2
+            ),
+            Trains::DTO::Migration.new(
+              table_name: 'ForumThread',
+              modifier: :add_column,
+              fields: [Trains::DTO::Field.new(:expression1_count, :integer)],
+              version: 4.2
+            ),
+            Trains::DTO::Migration.new(
+              table_name: 'ForumThread',
+              modifier: :add_column,
+              fields: [Trains::DTO::Field.new(:expression2_count, :integer)],
+              version: 4.2
+            )
+          ]
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
**Changes:**
1. Scan denormalized migrations to return one migration per send call
2. Refactor migration visitor to accommodate new logic and make it more robust
3. Add test for denormalized migrations
4. Bump version to 0.0.9