### PR TITLE
Schema by default

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -2,3 +2,6 @@ version = 1
 
 [[analyzers]]
 name = "ruby"
+
+[[analyzers]]
+name = "shell"

--- a/lib/trains/scanner.rb
+++ b/lib/trains/scanner.rb
@@ -46,9 +46,12 @@ module Trains
 
     # Stitch together migrations to create models
     def generate_models
+      # Parse models from schema.rb (used when brownfield project)
+      schema_models = parse_schema
+
       migrations = get_migrations.flatten.reject(&:nil?)
       migrations = [*migrations, *parse_models.flatten.reject(&:nil?)]
-      Utils::MigrationTailor.stitch(migrations)
+      Utils::MigrationTailor.stitch(schema_models, migrations)
     end
 
     def get_routes

--- a/lib/trains/utils/migration_tailor.rb
+++ b/lib/trains/utils/migration_tailor.rb
@@ -1,18 +1,19 @@
 module Trains
   module Utils
     module MigrationTailor
-      def self.stitch(migrations)
-        models = {}
-
+      def self.stitch(models = {}, migrations)
         migrations.each do |mig|
           case mig.modifier
           when :create_table, :create_join_table
-            models[mig.table_name] = {}
-            models[mig.table_name] = Trains::DTO::Model.new(
-              name: mig.table_name,
-              fields: mig.fields,
-              version: mig.version
-            )
+            if models.key?(mig.table_name)
+              models[mig.table_name].fields.push(*mig.fields)
+            else
+              models[mig.table_name] = Trains::DTO::Model.new(
+                name: mig.table_name,
+                fields: mig.fields,
+                version: mig.version
+              )
+            end
           when :add_column, :add_column_with_default, :add_reference
             models[mig.table_name].fields.push(*mig.fields)
           when :remove_column

--- a/lib/trains/version.rb
+++ b/lib/trains/version.rb
@@ -1,3 +1,3 @@
 module Trains
-  VERSION = '0.0.16'.freeze
+  VERSION = '0.0.17'.freeze
 end

--- a/lib/trains/visitor/schema.rb
+++ b/lib/trains/visitor/schema.rb
@@ -9,9 +9,9 @@ module Trains
       PATTERN
 
       def_node_matcher :unversioned_schema?, <<~PATTERN
-       (block
-        (send (const (const nil? :ActiveRecord) :Schema) :define ...)
-       ...)
+        (block
+         (send (const (const nil? :ActiveRecord) :Schema) :define ...)
+        ...)
       PATTERN
 
       def initialize
@@ -64,7 +64,7 @@ module Trains
             next if child.method?(:index)
 
             DTO::Field.new(
-              name: child.first_argument.str_content,
+              name: child.first_argument.str_content.to_sym,
               type: child.method_name
             )
           end

--- a/spec/lib/trains/utils/migration_tailor_spec.rb
+++ b/spec/lib/trains/utils/migration_tailor_spec.rb
@@ -2,6 +2,17 @@
 
 describe Trains::Utils::MigrationTailor do
   context 'when migrations create_table, add_column' do
+    let(:models_from_schema) do
+      {
+        'Post' => Trains::DTO::Model.new(
+          name: 'Post',
+          fields: [
+            Trains::DTO::Field.new(:name, :string),
+          ],
+          version: 6.3
+        )
+      }
+    end
     let(:create_add_migs) do
       [
         Trains::DTO::Migration.new(
@@ -25,18 +36,19 @@ describe Trains::Utils::MigrationTailor do
     end
 
     it 'creates a model and adds a column to it' do
-      models = Trains::Utils::MigrationTailor.stitch(create_add_migs)
+      models = Trains::Utils::MigrationTailor.stitch(models_from_schema, create_add_migs)
       expect(models).to eq(
         {
           'Post' =>
         Trains::DTO::Model.new(
           name: 'Post',
           fields: [
+            Trains::DTO::Field.new(:name, :string),
             Trains::DTO::Field.new(:title, :string),
             Trains::DTO::Field.new(:more, :text),
             Trains::DTO::Field.new(:user_name, :string)
           ],
-          version: 5.2
+          version: 6.3
         )
         }
       )


### PR DESCRIPTION
When a brownfield project uses an already existing DB, a schema.rb will exist that represents the state of the models, parse that and combine those models with the migrations