### PR TITLE
feat: Add support for removed, renamed and ignored columns

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -2,3 +2,6 @@ version = 1
 
 [[analyzers]]
 name = "ruby"
+
+[[analyzers]]
+name = "shell"

--- a/lib/trains/dto/model.rb
+++ b/lib/trains/dto/model.rb
@@ -1,5 +1,12 @@
 module Trains
   module DTO
-    Model = Data.define(:name, :fields, :version)
+    Model = Data.define(
+      :name, :fields, :version, :renamed_columns, :removed_columns, :ignored_columns
+    ) do
+      def initialize(name:, fields:, version:, renamed_columns: [],
+                     removed_columns: [], ignored_columns: [])
+        super(name:, fields:, version:, renamed_columns:, removed_columns:, ignored_columns:)
+      end
+    end
   end
 end

--- a/lib/trains/dto/rename.rb
+++ b/lib/trains/dto/rename.rb
@@ -1,0 +1,5 @@
+module Trains
+  module DTO
+    Rename = Data.define(:from, :to)
+  end
+end

--- a/lib/trains/utils/migration_tailor.rb
+++ b/lib/trains/utils/migration_tailor.rb
@@ -33,14 +33,14 @@ module Trains
               end
             models[mig.table_name].fields.push(
               Trains::DTO::Field.new(
-                name: mig.fields.first.type,
+                name: mig.fields.first.type.to_sym,
                 type: column.type
               )
             )
             models[mig.table_name].fields.delete(column)
             models[mig.table_name].renamed_columns.push(
               Trains::DTO::Rename.new(
-                from: mig.fields.first.name, to: mig.fields.first.type
+                from: mig.fields.first.name.to_sym, to: mig.fields.first.type.to_sym
               )
             )
           when :change_table
@@ -62,7 +62,7 @@ module Trains
                 # Create new field from temp with new name
                 models[mig.table_name].fields.push(
                   Trains::DTO::Field.new(
-                    name: field.name[1],
+                    name: field.name[1].to_sym,
                     type: column.type
                   )
                 )

--- a/lib/trains/utils/migration_tailor.rb
+++ b/lib/trains/utils/migration_tailor.rb
@@ -25,6 +25,7 @@ module Trains
                 field.name == mig.fields.first.name
               end
             models[mig.table_name].fields.delete(column)
+            models[mig.table_name].removed_columns.push(mig.fields.first.name)
           when :rename_column
             column =
               models[mig.table_name].fields.find do |field|
@@ -32,11 +33,16 @@ module Trains
               end
             models[mig.table_name].fields.push(
               Trains::DTO::Field.new(
-                name: mig.fields.first.type.to_sym,
+                name: mig.fields.first.type,
                 type: column.type
               )
             )
             models[mig.table_name].fields.delete(column)
+            models[mig.table_name].renamed_columns.push(
+              Trains::DTO::Rename.new(
+                from: mig.fields.first.name, to: mig.fields.first.type
+              )
+            )
           when :change_table
             mig.fields.each do |field|
               case field.type
@@ -46,6 +52,7 @@ module Trains
                     mod_field.name == field.name
                   end
                 models[mig.table_name].fields.delete(column)
+                models[mig.table_name].removed_columns.push(field.name)
               when :rename
                 # find the field and store temporarily
                 column =
@@ -61,6 +68,11 @@ module Trains
                 )
                 # Delete the field
                 models[mig.table_name].fields.delete(column)
+                models[mig.table_name].renamed_columns.push(
+                  Trains::DTO::Rename.new(
+                    from: field.name[0], to: field.name[1]
+                  )
+                )
               else
                 models[mig.table_name].fields.push(field)
               end

--- a/lib/trains/utils/migration_tailor.rb
+++ b/lib/trains/utils/migration_tailor.rb
@@ -19,6 +19,8 @@ module Trains
             end
           when :add_column, :add_column_with_default, :add_reference
             models[mig.table_name].fields.push(*mig.fields)
+          when :ignore_column
+            models[mig.table_name].ignored_columns.push(*mig.fields.map(&:name))
           when :remove_column
             column =
               models[mig.table_name].fields.find do |field|

--- a/lib/trains/version.rb
+++ b/lib/trains/version.rb
@@ -1,3 +1,3 @@
 module Trains
-  VERSION = '0.0.19'.freeze
+  VERSION = '0.1.0'.freeze
 end

--- a/lib/trains/visitor/model.rb
+++ b/lib/trains/visitor/model.rb
@@ -39,13 +39,13 @@ module Trains
 
           arguments = node.arguments.first.to_a
           arguments = arguments.select do |child|
-            child.is_a?(RuboCop::AST::SymbolNode)
+            child.is_a?(RuboCop::AST::SymbolNode) || child.is_a?(RuboCop::AST::StrNode)
           end.map(&:value)
 
           @result << DTO::Migration.new(
             @model_class,
             :ignore_column,
-            [*arguments.map { |arg| DTO::Field.new(arg, nil) }],
+            [*arguments.map { |arg| DTO::Field.new(arg.to_sym, nil) }],
             nil
           )
 

--- a/lib/trains/visitor/model.rb
+++ b/lib/trains/visitor/model.rb
@@ -9,6 +9,7 @@ module Trains
         belongs_to
         has_one
         has_and_belongs_to_many
+        ignored_columns=
       ].freeze
       MODEL_PARENT_CLASSES = %w[
         ApplicationRecord
@@ -31,6 +32,25 @@ module Trains
 
       def parse_model(node)
         return unless POSSIBLE_ASSOCIATIONS.include?(node.method_name)
+
+        if node.method_name == :ignored_columns=
+          return if node.arguments.nil?
+          return unless node.arguments.first.is_a? RuboCop::AST::ArrayNode
+
+          arguments = node.arguments.first.to_a
+          arguments = arguments.select do |child|
+            child.is_a?(RuboCop::AST::SymbolNode)
+          end.map(&:value)
+
+          @result << DTO::Migration.new(
+            @model_class,
+            :ignore_column,
+            [*arguments.map { |arg| DTO::Field.new(arg, nil) }],
+            nil
+          )
+
+          return
+        end
 
         @result << DTO::Migration.new(
           @model_class,

--- a/spec/lib/trains/utils/migration_tailor_spec.rb
+++ b/spec/lib/trains/utils/migration_tailor_spec.rb
@@ -89,7 +89,8 @@ describe Trains::Utils::MigrationTailor do
           fields: [
             Trains::DTO::Field.new(:more, :text)
           ],
-          version: 5.2
+          version: 5.2,
+          removed_columns: [:title]
         )
         }
       )
@@ -201,7 +202,13 @@ describe Trains::Utils::MigrationTailor do
               Trains::DTO::Field.new(:updated_at, :datetime),
               Trains::DTO::Field.new(:alive_since, :integer),
               Trains::DTO::Field.new(:name, :string)
-            ]
+            ],
+            renamed_columns: [
+              Trains::DTO::Rename.new(:name, :whatup),
+              Trains::DTO::Rename.new(:age, :alive_since),
+              Trains::DTO::Rename.new(:whatup, :name)
+            ],
+            removed_columns: %i[title]
           )
         }
       )

--- a/spec/lib/trains/visitor/model_spec.rb
+++ b/spec/lib/trains/visitor/model_spec.rb
@@ -14,12 +14,16 @@ describe Trains::Visitor::Model do
 
       expect(parser.result).to eq(
         [
-        Trains::DTO::Migration.new(
-          table_name: 'AccountPin',
-          modifier: :ignore_column,
-          fields: [Trains::DTO::Field.new(:foo, nil), Trains::DTO::Field.new(:baz, nil)],
-          version: nil
-        )
+          Trains::DTO::Migration.new(
+            table_name: 'AccountPin',
+            modifier: :ignore_column,
+            fields: [
+              Trains::DTO::Field.new(:foo, nil),
+              Trains::DTO::Field.new(:baz, nil),
+              Trains::DTO::Field.new(:what, nil)
+            ],
+            version: nil
+          )
         ]
       )
     end


### PR DESCRIPTION
Changes:
1. When a column is removed, renamed, or set as ignored, created migrations for this.
2. Add separate child keys for removed, renamed and ignored columns in DTO::Model
3. Represent renamed column using a separate DTO::Rename